### PR TITLE
Relax types for backwards compatibility with spacy v3

### DIFF
--- a/wasabi/printer.py
+++ b/wasabi/printer.py
@@ -7,7 +7,7 @@ import traceback
 from collections import Counter
 from contextlib import contextmanager
 from multiprocessing import Process
-from typing import Collection, Dict, Optional, Union, cast
+from typing import Any, Collection, Dict, Optional, Union, cast
 
 from .tables import row, table
 from .util import COLORS, ICONS, MESSAGES, can_render
@@ -73,16 +73,16 @@ class Printer(object):
 
     def good(
         self,
-        title: str = "",
-        text: str = "",
+        title: Any = "",
+        text: Any = "",
         show: bool = True,
         spaced: bool = False,
         exits: Optional[int] = None,
     ):
         """Print a success message.
 
-        title (str): The main text to print.
-        text (str): Optional additional text to print.
+        title (Any): The main text to print.
+        text (Any): Optional additional text to print.
         show (bool): Whether to print or not. Can be used to only output
             messages under certain condition, e.g. if --verbose flag is set.
         spaced (bool): Whether to add newlines around the output.
@@ -94,37 +94,38 @@ class Printer(object):
 
     def fail(
         self,
-        title: str = "",
-        text: str = "",
-        show: bool = True,
-        spaced: bool = False,
-        exits: Optional[int] = None,
+        title: Any = "",
+        text: Any = "",
+        **kwargs,
     ):
         """Print an error message.
 
-        title (str): The main text to print.
-        text (str): Optional additional text to print.
+        title (Any): The main text to print.
+        text (Any): Optional additional text to print.
         show (bool): Whether to print or not. Can be used to only output
             messages under certain condition, e.g. if --verbose flag is set.
         spaced (bool): Whether to add newlines around the output.
         exits (Optional[int]): Optional toggle to perform a system exit.
         """
+        show: bool = kwargs.get("show", True)
+        spaced: bool = kwargs.get("spaced", False)
+        exits: Optional[int] = kwargs.get("exits", None)
         return self._get_msg(
             title, text, style=MESSAGES.FAIL, show=show, spaced=spaced, exits=exits
         )
 
     def warn(
         self,
-        title: str = "",
-        text: str = "",
+        title: Any = "",
+        text: Any = "",
         show: bool = True,
         spaced: bool = False,
         exits: Optional[int] = None,
     ):
         """Print a warning message.
 
-        title (str): The main text to print.
-        text (str): Optional additional text to print.
+        title (Any): The main text to print.
+        text (Any): Optional additional text to print.
         show (bool): Whether to print or not. Can be used to only output
             messages under certain condition, e.g. if --verbose flag is set.
         spaced (bool): Whether to add newlines around the output.
@@ -136,16 +137,16 @@ class Printer(object):
 
     def info(
         self,
-        title: str = "",
-        text: str = "",
+        title: Any = "",
+        text: Any = "",
         show: bool = True,
         spaced: bool = False,
         exits: Optional[int] = None,
     ):
         """Print an informational message.
 
-        title (str): The main text to print.
-        text (str): Optional additional text to print.
+        title (Any): The main text to print.
+        text (Any): Optional additional text to print.
         show (bool): Whether to print or not. Can be used to only output
             messages under certain condition, e.g. if --verbose flag is set.
         spaced (bool): Whether to add newlines around the output.
@@ -157,8 +158,8 @@ class Printer(object):
 
     def text(
         self,
-        title: str = "",
-        text: str = "",
+        title: Any = "",
+        text: Any = "",
         color: Optional[Union[str, int]] = None,
         bg_color: Optional[Union[str, int]] = None,
         icon: Optional[str] = None,
@@ -169,8 +170,8 @@ class Printer(object):
     ):
         """Print a message.
 
-        title (str): The main text to print.
-        text (str): Optional additional text to print.
+        title (Any): The main text to print.
+        text (Any): Optional additional text to print.
         color (Optional[Union[str, int]]): Optional foreground color.
         bg_color (Optional[Union[str, int]]): Optional background color.
         icon (Optional[str]): Optional name of icon to add.
@@ -307,8 +308,8 @@ class Printer(object):
 
     def _get_msg(
         self,
-        title: str,
-        text: str,
+        title: Any,
+        text: Any,
         style: Optional[str] = None,
         show: bool = False,
         spaced: bool = False,

--- a/wasabi/printer.py
+++ b/wasabi/printer.py
@@ -96,7 +96,9 @@ class Printer(object):
         self,
         title: Any = "",
         text: Any = "",
-        **kwargs,
+        show: bool = True,
+        spaced: bool = False,
+        exits: Optional[int] = None,
     ):
         """Print an error message.
 
@@ -107,9 +109,6 @@ class Printer(object):
         spaced (bool): Whether to add newlines around the output.
         exits (Optional[int]): Optional toggle to perform a system exit.
         """
-        show: bool = kwargs.get("show", True)
-        spaced: bool = kwargs.get("spaced", False)
-        exits: Optional[int] = kwargs.get("exits", None)
         return self._get_msg(
             title, text, style=MESSAGES.FAIL, show=show, spaced=spaced, exits=exits
         )

--- a/wasabi/util.py
+++ b/wasabi/util.py
@@ -90,6 +90,7 @@ def wrap(text: str, wrap_max: int = 80, indent: int = 4) -> str:
     """
     indent_str = indent * " "
     wrap_width = wrap_max - len(indent_str)
+    text = str(text)
     return textwrap.fill(
         text,
         width=wrap_width,
@@ -178,6 +179,7 @@ def locale_escape(string: str, errors: str = "replace") -> str:
     errors (str): The str.encode errors setting. Defaults to `"replace"`.
     RETURNS (str): The escaped string.
     """
+    string = str(string)
     string = string.encode(ENCODING, errors).decode("utf8")
     return string
 

--- a/wasabi/util.py
+++ b/wasabi/util.py
@@ -80,10 +80,10 @@ def color(
     return "\x1b[{}m{}\x1b[0m".format(";".join(styles), text)
 
 
-def wrap(text: str, wrap_max: int = 80, indent: int = 4) -> str:
+def wrap(text: Any, wrap_max: int = 80, indent: int = 4) -> str:
     """Wrap text at given width using textwrap module.
 
-    text (str): The text to wrap.
+    text (Any): The text to wrap.
     wrap_max (int): Maximum line width, including indentation. Defaults to 80.
     indent (int): Number of spaces used for indentation. Defaults to 4.
     RETURNS (str): The wrapped text with line breaks.
@@ -172,10 +172,10 @@ def get_raw_input(
     return user_input
 
 
-def locale_escape(string: str, errors: str = "replace") -> str:
+def locale_escape(string: Any, errors: str = "replace") -> str:
     """Mangle non-supported characters, for savages with ASCII terminals.
 
-    string (str): The string to escape.
+    string (Any): The string to escape.
     errors (str): The str.encode errors setting. Defaults to `"replace"`.
     RETURNS (str): The escaped string.
     """


### PR DESCRIPTION
Relax types for backwards compatibility with current use of `wasabi` in `spacy`, tested with v3.4.1.