### PR TITLE
Set version to v1.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 1.0.0
+version = 1.1.0
 description = A lightweight console printing and formatting toolkit
 url = https://github.com/explosion/wasabi
 author = Explosion


### PR DESCRIPTION
This is only v1.1.0 due the current `wasabi` range of `<1.1.0` in many projects. It's a little weird to have v1.1 without v1.0, and it could also be fine to make it v2.0 instead.