### PR TITLE
Add support for ANSI on Windows

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+recursive-include wasabi/tests/test-data *.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 typing_extensions
 mypy
+types-colorama

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest
 typing_extensions
 mypy
 types-colorama
+jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ typing_extensions
 mypy
 types-colorama
 nbconvert
+ipykernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pytest
 typing_extensions
 mypy
 types-colorama
-jupyter; python_version >= "3.7"
+nbconvert

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pytest
 typing_extensions
 mypy
 types-colorama
-jupyter
+jupyter; python_version >= "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ zip_safe = true
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-    colorama >= 0.4.6; sys_platform == "win32"
+    colorama >= 0.4.6; sys_platform == "win32" and python_version >= "3.7"
 
 [flake8]
 ignore = E203, E266, E501, E731, W503, E741

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,8 @@ long_description_content_type = text/markdown
 zip_safe = true
 include_package_data = true
 python_requires = >=3.6
+install_requires =
+    colorama >= 0.4.6; sys_platform == "win32"
 
 [flake8]
 ignore = E203, E266, E501, E731, W503, E741

--- a/wasabi/tests/test-data/wasabi-test-notebook.ipynb
+++ b/wasabi/tests/test-data/wasabi-test-notebook.ipynb
@@ -7,11 +7,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import wasabi\n",
-    "wasabi.msg.warn(\"This is a test. This is only a test.\")\n",
-    "assert wasabi.util.supports_ansi()\n",
-    "\n",
     "import sys\n",
+    "import wasabi\n",
+    "\n",
+    "wasabi.msg.warn(\"This is a test. This is only a test.\")\n",
+    "if sys.version_info >= (3, 7):\n",
+    "    assert wasabi.util.supports_ansi()\n",
+    "\n",
     "print(sys.stdout)"
    ]
   }

--- a/wasabi/tests/test-data/wasabi-test-notebook.ipynb
+++ b/wasabi/tests/test-data/wasabi-test-notebook.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb5586f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import wasabi\n",
+    "wasabi.msg.warn(\"This is a test. This is only a test.\")\n",
+    "assert wasabi.util.supports_ansi()\n",
+    "\n",
+    "import sys\n",
+    "print(sys.stdout)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/wasabi/tests/test_jupyter.py
+++ b/wasabi/tests/test_jupyter.py
@@ -1,11 +1,22 @@
 from pathlib import Path
 import subprocess
+import os
+
+import wasabi
 
 TEST_DATA = Path(__file__).absolute().parent / "test-data"
-
+WASABI_DIR = Path(wasabi.__file__).absolute().parent.parent
 
 def test_jupyter():
-    result = subprocess.run(
+    # Make sure that the notebook can 'import wasabi', and will get the version of
+    # wasabi under test. (Important if we're running tests out of the source tree.)
+    env = dict(os.environ)
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{WASABI_DIR}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(WASABI_DIR)
+    print(env["PYTHONPATH"])
+    subprocess.run(
         [
             "jupyter",
             "nbconvert",
@@ -15,5 +26,6 @@ def test_jupyter():
             "--to",
             "notebook",
         ],
+        env=env,
         check=True,
     )

--- a/wasabi/tests/test_jupyter.py
+++ b/wasabi/tests/test_jupyter.py
@@ -1,19 +1,14 @@
-import pytest
-
 from pathlib import Path
 import subprocess
 import os
-import shutil
+import sys
 
 import wasabi
-
-jupyter_missing = shutil.which("jupyter") is None
 
 TEST_DATA = Path(__file__).absolute().parent / "test-data"
 WASABI_DIR = Path(wasabi.__file__).absolute().parent.parent
 
 
-@pytest.mark.skipif(jupyter_missing, reason="no jupyter install")
 def test_jupyter():
     # Make sure that the notebook can 'import wasabi', and will get the version of
     # wasabi under test. (Important if we're running tests out of the source tree.)
@@ -24,7 +19,8 @@ def test_jupyter():
         env["PYTHONPATH"] = str(WASABI_DIR)
     subprocess.run(
         [
-            "jupyter",
+            sys.executable,
+            "-m",
             "nbconvert",
             str(TEST_DATA / "wasabi-test-notebook.ipynb"),
             "--execute",

--- a/wasabi/tests/test_jupyter.py
+++ b/wasabi/tests/test_jupyter.py
@@ -3,21 +3,17 @@ import pytest
 from pathlib import Path
 import subprocess
 import os
+import shutil
 
 import wasabi
 
-try:
-    import jupyter
-except ImportError:
-    have_jupyter = False
-else:
-    have_jupyter = True
+jupyter_missing = shutil.which("jupyter") is None
 
 TEST_DATA = Path(__file__).absolute().parent / "test-data"
 WASABI_DIR = Path(wasabi.__file__).absolute().parent.parent
 
 
-@pytest.mark.skipif(not have_jupyter, reason="no jupyter install")
+@pytest.mark.skipif(jupyter_missing, reason="no jupyter install")
 def test_jupyter():
     # Make sure that the notebook can 'import wasabi', and will get the version of
     # wasabi under test. (Important if we're running tests out of the source tree.)

--- a/wasabi/tests/test_jupyter.py
+++ b/wasabi/tests/test_jupyter.py
@@ -1,12 +1,23 @@
+import pytest
+
 from pathlib import Path
 import subprocess
 import os
 
 import wasabi
 
+try:
+    import jupyter
+except ImportError:
+    have_jupyter = False
+else:
+    have_jupyter = True
+
 TEST_DATA = Path(__file__).absolute().parent / "test-data"
 WASABI_DIR = Path(wasabi.__file__).absolute().parent.parent
 
+
+@pytest.mark.skipif(not have_jupyter, reason="no jupyter install")
 def test_jupyter():
     # Make sure that the notebook can 'import wasabi', and will get the version of
     # wasabi under test. (Important if we're running tests out of the source tree.)
@@ -15,7 +26,6 @@ def test_jupyter():
         env["PYTHONPATH"] = f"{WASABI_DIR}{os.pathsep}{env['PYTHONPATH']}"
     else:
         env["PYTHONPATH"] = str(WASABI_DIR)
-    print(env["PYTHONPATH"])
     subprocess.run(
         [
             "jupyter",

--- a/wasabi/tests/test_jupyter.py
+++ b/wasabi/tests/test_jupyter.py
@@ -20,7 +20,7 @@ def test_jupyter():
         [
             "jupyter",
             "nbconvert",
-            TEST_DATA / "wasabi-test-notebook.ipynb",
+            str(TEST_DATA / "wasabi-test-notebook.ipynb"),
             "--execute",
             "--stdout",
             "--to",

--- a/wasabi/tests/test_jupyter.py
+++ b/wasabi/tests/test_jupyter.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import subprocess
+
+TEST_DATA = Path(__file__).absolute().parent / "test-data"
+
+
+def test_jupyter():
+    result = subprocess.run(
+        [
+            "jupyter",
+            "nbconvert",
+            TEST_DATA / "wasabi-test-notebook.ipynb",
+            "--execute",
+            "--stdout",
+            "--to",
+            "notebook",
+        ],
+        check=True,
+    )

--- a/wasabi/tests/test_jupyter.py
+++ b/wasabi/tests/test_jupyter.py
@@ -10,8 +10,11 @@ WASABI_DIR = Path(wasabi.__file__).absolute().parent.parent
 
 
 def test_jupyter():
-    # Make sure that the notebook can 'import wasabi', and will get the version of
-    # wasabi under test. (Important if we're running tests out of the source tree.)
+    # This runs some code in a jupyter notebook environment, but without actually
+    # starting up the notebook UI. Historically we once had a bug that caused crashes
+    # when importing wasabi in a jupyter notebook, because they replace
+    # sys.stdout/stderr with custom objects that aren't "real" files/ttys. So this makes
+    # sure that we can import and use wasabi inside a notebook without crashing.
     env = dict(os.environ)
     if "PYTHONPATH" in env:
         env["PYTHONPATH"] = f"{WASABI_DIR}{os.pathsep}{env['PYTHONPATH']}"

--- a/wasabi/util.py
+++ b/wasabi/util.py
@@ -212,12 +212,12 @@ def supports_ansi() -> bool:
     # doesn't have just_fix_windows_console. So we need to confirm not just that we can
     # import colorama, but that we can import just_fix_windows_console.
     try:
-        from colorama import just_fix_windows_console
+        from colorama import just_fix_windows_console  # type: ignore
     except ImportError:
         if sys.platform == "win32" and "ANSICON" not in os.environ:
             return False
     else:
         # type ignore required until this lands:
         #   https://github.com/python/typeshed/pull/9234
-        just_fix_windows_console()  # type: ignore
+        just_fix_windows_console()
     return True

--- a/wasabi/util.py
+++ b/wasabi/util.py
@@ -206,12 +206,18 @@ def supports_ansi() -> bool:
     """
     if os.getenv(ENV_ANSI_DISABLED):
         return False
+    # We require colorama on Windows Python 3.7+, but we might be running on Unix, or we
+    # might be running on Windows Python 3.6. In both cases, colorama might be missing,
+    # *or* there might by accident happen to be an install of an old version that
+    # doesn't have just_fix_windows_console. So we need to confirm not just that we can
+    # import colorama, but that we can import just_fix_windows_console.
     try:
-        import colorama
+        from colorama import just_fix_windows_console
     except ImportError:
-        pass
+        if sys.platform == "win32" and "ANSICON" not in os.environ:
+            return False
     else:
         # type ignore required until this lands:
         #   https://github.com/python/typeshed/pull/9234
-        colorama.just_fix_windows_console()  # type: ignore
+        just_fix_windows_console()  # type: ignore
     return True

--- a/wasabi/util.py
+++ b/wasabi/util.py
@@ -200,17 +200,16 @@ def can_render(string: str) -> bool:
 
 def supports_ansi() -> bool:
     """Returns True if the running system's terminal supports ANSI escape
-    sequences for color, formatting etc. and False otherwise. Inspired by
-    Django's solution – hacky, but an okay approximation.
+    sequences for color, formatting etc. and False otherwise.
 
     RETURNS (bool): Whether the terminal supports ANSI colors.
     """
     if os.getenv(ENV_ANSI_DISABLED):
         return False
-    # See: https://stackoverflow.com/q/7445658/6400719
-    supported_platform = sys.platform != "Pocket PC" and (
-        sys.platform != "win32" or "ANSICON" in os.environ
-    )
-    if not supported_platform:
-        return False
+    try:
+        import colorama
+    except ImportError:
+        pass
+    else:
+        colorama.just_fix_windows_console()
     return True

--- a/wasabi/util.py
+++ b/wasabi/util.py
@@ -212,12 +212,10 @@ def supports_ansi() -> bool:
     # doesn't have just_fix_windows_console. So we need to confirm not just that we can
     # import colorama, but that we can import just_fix_windows_console.
     try:
-        from colorama import just_fix_windows_console  # type: ignore
+        from colorama import just_fix_windows_console
     except ImportError:
         if sys.platform == "win32" and "ANSICON" not in os.environ:
             return False
     else:
-        # type ignore required until this lands:
-        #   https://github.com/python/typeshed/pull/9234
         just_fix_windows_console()
     return True

--- a/wasabi/util.py
+++ b/wasabi/util.py
@@ -211,5 +211,7 @@ def supports_ansi() -> bool:
     except ImportError:
         pass
     else:
-        colorama.just_fix_windows_console()
+        # type ignore required until this lands:
+        #   https://github.com/python/typeshed/pull/9234
+        colorama.just_fix_windows_console()  # type: ignore
     return True


### PR DESCRIPTION
This is a belated replacement for the reverted #24.

Improvements this time around:

Moved the relevant code into upstream colorama, so it plays nicely with other packages using terminal features on Windows, like tqdm.

This also gives us basic ANSI support on any old Windows installs out there that still don't have the native ANSI support. I think they're all EOL already so not a big deal, but it's a free bonus, so why not.

Last time, we had to revert due to a bug in handling "fake" consoles like Jupyter notebooks. This time, we're using code that's already been out in the wild for ~1 month with no issues reported, so hopefully there won't be any need for emergency reverts.

CC @richardpaulhudson 