### PR TITLE
Adding GitHub Action workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-11, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,3 +40,9 @@ jobs:
           python -c "import sys; print('stdout encoding:', sys.stdout.encoding)"
           env
           python -m pytest -s wasabi
+
+      - name: Run mypy
+        run: python -m mypy wasabi
+
+      - name: Test sdist
+        run: python setup.py sdist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on: push
 jobs:
   tests:
     strategy:
-      max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: tests
 
-on: push
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        # TODO: keep it cheap while testing. Replace when ready to use the full array.
-        # os: [ubuntu-latest, windows-latest, macos-11, macos-latest]
-        os: [ubuntu-latest, ubuntu-18.04]
+        os: [ubuntu-latest, windows-latest, macos-11, macos-latest]
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: tests
+
+on: push
+
+jobs:
+  tests:
+    strategy:
+      max-parallel: 4
+      matrix:
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-latest,
+            windows-2019,
+            windows-latest,
+            macos-11,
+            macos-latest,
+          ]
+        python_version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        exclude:
+          - os: ubuntu-20.04
+            version: [3.7, 3.8, 3.9, 3.10, 3.11]
+          - os: windows-2019
+            version: [3.7, 3.8, 3.9, 3.10, 3.11]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+          architecture: x64
+          cache: "pip"
+      - run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,9 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-11, macos-latest]
+        # TODO: keep it cheap while testing. Replace when ready to use the full array.
+        # os: [ubuntu-latest, windows-latest, macos-11, macos-latest]
+        os: [ubuntu-latest, ubuntu-18.04]
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: ubuntu-20.04
@@ -20,12 +22,21 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
 
-      - name: Install dependencies
+      - name: Configure Python version
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64
           cache: "pip"
-      - run: |
+
+      - name: Install dependencies
+        run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
+
+      - name: Run pytest
+        run: |
+          python -c "import locale; print('Preferred encoding:', locale.getpreferredencoding())"
+          python -c "import sys; print('stdout encoding:', sys.stdout.encoding)"
+          env
+          python -m pytest -s wasabi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,21 +7,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os:
-          [
-            ubuntu-20.04,
-            ubuntu-latest,
-            windows-2019,
-            windows-latest,
-            macos-11,
-            macos-latest,
-          ]
-        python_version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
-        exclude:
+        os: [ubuntu-latest, windows-latest, macos-11, macos-latest]
+        python_version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        include:
           - os: ubuntu-20.04
-            version: [3.7, 3.8, 3.9, 3.10, 3.11]
+            python_version: "3.6"
           - os: windows-2019
-            version: [3.7, 3.8, 3.9, 3.10, 3.11]
+            python_version: "3.6"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest, macos-11, macos-latest]
-        python_version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: ubuntu-20.04
             python_version: "3.6"


### PR DESCRIPTION
Hi folks!

As mentioned, we're moving out of Azure Pipelines for GitHub Actions. This PR is adding the new workflow: I will remove the old one when we're all happy with the results.

You can see the action running in my fork here: https://github.com/patjouk/wasabi/actions/runs/4017049398.
Since we don't need a limit on concurrent runners, tests are faster:
- Run time on Azure: 9min.
- Run time on GHA: 4min.

@ryndaniels for visibility.

