### PR TITLE
CI: Set fail fast to false

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
As [requested here](https://github.com/explosion/wasabi/pull/37), fail fast is now false: a failing test won't cancel all the others.