### PR TITLE
Bump typing_extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
+typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
 # Development dependencies
 pytest
 mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 1.1.2
+version = 1.1.3
 description = A lightweight console printing and formatting toolkit
 url = https://github.com/explosion/wasabi
 author = Explosion

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     colorama >= 0.4.6; sys_platform == "win32" and python_version >= "3.7"
-    typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
+    typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
 
 [flake8]
 ignore = E203, E266, E501, E731, W503, E741


### PR DESCRIPTION
Allow up to `typing_extensions<5.0.0` for Python < 3.8 to avoid install conflicts.

Bumping `wasabi` to `1.1.3`.